### PR TITLE
handle multiple issues (attachments) in one alert

### DIFF
--- a/glitchtip_jira_bridge/api/v1/alert.py
+++ b/glitchtip_jira_bridge/api/v1/alert.py
@@ -30,4 +30,5 @@ def handle_alert(
     create_jira_ticket: Task = Depends(get_create_jira_ticket_func),
 ) -> None:
     """Create new snapshot on all volumes."""
-    create_jira_ticket.delay(jira_project_key, alert)
+    for attachment in alert.attachments:
+        create_jira_ticket.delay(jira_project_key, attachment)

--- a/glitchtip_jira_bridge/models.py
+++ b/glitchtip_jira_bridge/models.py
@@ -16,6 +16,21 @@ class Attachment(BaseModel):
     fields: list[Field] | None = None
     mrkdown_in: list[str] | None = None
 
+    @property
+    def labels(self) -> list[str]:
+        l: list[str] = []
+        for f in self.fields or []:
+            match f.title.lower():
+                case "project":
+                    l.append(f"project:{f.value}")
+                case "release":
+                    l.append(f"release:{f.value}")
+                case "environment":
+                    l.append(f"environment:{f.value}")
+                case _:
+                    pass
+        return l
+
 
 class GlitchtipAlert(BaseModel):
     alias: str
@@ -23,34 +38,6 @@ class GlitchtipAlert(BaseModel):
     attachments: list[Attachment]
     # pydantic config
     model_config = {"extra": "ignore"}
-
-    @property
-    def labels(self) -> list[str]:
-        l: list[str] = []
-        for a in self.attachments:
-            for f in a.fields or []:
-                match f.title.lower():
-                    case "project":
-                        l.append(f"project:{f.value}")
-                    case "release":
-                        l.append(f"release:{f.value}")
-                    case "environment":
-                        l.append(f"environment:{f.value}")
-                    case _:
-                        pass
-        return l
-
-    @property
-    def issue_title(self) -> str:
-        return self.attachments[0].title
-
-    @property
-    def issue_url(self) -> str:
-        return self.attachments[0].title_link
-
-    @property
-    def issue_text(self) -> str:
-        return self.attachments[0].text
 
 
 class Issue(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,10 @@ from fastapi.testclient import TestClient
 from glitchtip_jira_bridge.config import Settings
 from glitchtip_jira_bridge.config import settings as current_settings
 from glitchtip_jira_bridge.main import create_app
-from glitchtip_jira_bridge.models import GlitchtipAlert
+from glitchtip_jira_bridge.models import (
+    Attachment,
+    GlitchtipAlert,
+)
 
 
 @pytest.fixture
@@ -30,42 +33,47 @@ def config_debug(settings: Settings) -> bool:
 
 
 @pytest.fixture
-def glitchtip_alert() -> GlitchtipAlert:
+def issue() -> Attachment:
+    return Attachment(
+        **dict(
+            title="issue title",
+            title_link="https://glitchtip.devshift.net/app-sre/issues/12345",
+            text="issue text",
+            image_url="https://google.com",
+            color="#FF0000",
+            fields=[
+                dict(
+                    title="test",
+                    value="test",
+                    short=True,
+                ),
+                dict(
+                    title="Project",
+                    value="test-project",
+                    short=True,
+                ),
+                dict(
+                    title="Release",
+                    value="test-release",
+                    short=True,
+                ),
+                dict(
+                    title="Environment",
+                    value="test-environment",
+                    short=True,
+                ),
+            ],
+            mrkdown_in=["text"],
+        )
+    )
+
+
+@pytest.fixture
+def glitchtip_alert(issue: Attachment) -> GlitchtipAlert:
     return GlitchtipAlert(
         **dict(
             alias="test alias",
             text="test text",
-            attachments=[
-                dict(
-                    title="issue title",
-                    title_link="https://glitchtip.devshift.net/app-sre/issues/12345",
-                    text="issue text",
-                    image_url="https://google.com",
-                    color="#FF0000",
-                    fields=[
-                        dict(
-                            title="test",
-                            value="test",
-                            short=True,
-                        ),
-                        dict(
-                            title="Project",
-                            value="test-project",
-                            short=True,
-                        ),
-                        dict(
-                            title="Release",
-                            value="test-release",
-                            short=True,
-                        ),
-                        dict(
-                            title="Environment",
-                            value="test-environment",
-                            short=True,
-                        ),
-                    ],
-                    mrkdown_in=["text"],
-                )
-            ],
+            attachments=[issue.model_dump()],
         ),
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,52 +2,8 @@ from glitchtip_jira_bridge.models import GlitchtipAlert
 
 
 def test_glitchtip_alert(glitchtip_alert: GlitchtipAlert) -> None:
-    alert = GlitchtipAlert(
-        **dict(
-            alias="test alias",
-            text="test text",
-            attachments=[
-                dict(
-                    title="issue title",
-                    title_link="https://glitchtip.devshift.net/app-sre/issues/12345",
-                    text="issue text",
-                    image_url="https://google.com",
-                    color="#FF0000",
-                    fields=[
-                        dict(
-                            title="test",
-                            value="test",
-                            short=True,
-                        ),
-                        dict(
-                            title="Project",
-                            value="test-project",
-                            short=True,
-                        ),
-                        dict(
-                            title="Release",
-                            value="test-release",
-                            short=True,
-                        ),
-                        dict(
-                            title="Environment",
-                            value="test-environment",
-                            short=True,
-                        ),
-                    ],
-                    mrkdown_in=["text"],
-                )
-            ],
-        ),
-    )
-    assert glitchtip_alert.labels == [
+    assert glitchtip_alert.attachments[0].labels == [
         "project:test-project",
         "release:test-release",
         "environment:test-environment",
     ]
-    assert glitchtip_alert.issue_title == "issue title"
-    assert (
-        glitchtip_alert.issue_url
-        == "https://glitchtip.devshift.net/app-sre/issues/12345"
-    )
-    assert glitchtip_alert.issue_text == "issue text"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,38 +1,32 @@
 import pytest
-from jira import JIRA
 from pytest_mock import MockerFixture
 
-from glitchtip_jira_bridge.backends.jira import create_issue
-from glitchtip_jira_bridge.models import GlitchtipAlert
+from glitchtip_jira_bridge.models import Attachment
 from glitchtip_jira_bridge.tasks import create_jira_ticket
 
 
-def test_create_jira_ticket(
-    mocker: MockerFixture, glitchtip_alert: GlitchtipAlert
-) -> None:
+def test_create_jira_ticket(mocker: MockerFixture, issue: Attachment) -> None:
     create_issue_mock = mocker.patch(
         "glitchtip_jira_bridge.tasks.create_issue", autospec=True
     )
     mocker.patch("glitchtip_jira_bridge.tasks.JIRA", autospec=True)
     mocker.patch("glitchtip_jira_bridge.tasks.boto3", autospec=True)
 
-    create_jira_ticket(jira_project_key="TEST", alert=glitchtip_alert)
+    create_jira_ticket(jira_project_key="TEST", issue=issue)
 
     create_issue_mock.assert_called_once_with(
         project_key="TEST",
-        summary=glitchtip_alert.issue_title,
+        summary=issue.title,
         description="issue text\n-----\nGlitchtip issue: https://glitchtip.devshift.net/app-sre/issues/12345",
         url="https://glitchtip.devshift.net/app-sre/issues/12345",
-        labels=["glitchtip"] + glitchtip_alert.labels,
+        labels=["glitchtip"] + issue.labels,
         jira=mocker.ANY,
         issue_cache=mocker.ANY,
         limits=mocker.ANY,
     )
 
 
-def test_create_jira_ticket_retry(
-    mocker: MockerFixture, glitchtip_alert: GlitchtipAlert
-) -> None:
+def test_create_jira_ticket_retry(mocker: MockerFixture, issue: Attachment) -> None:
     create_issue_mock = mocker.patch(
         "glitchtip_jira_bridge.tasks.create_issue", autospec=True
     )
@@ -41,4 +35,4 @@ def test_create_jira_ticket_retry(
     mocker.patch("glitchtip_jira_bridge.tasks.boto3", autospec=True)
 
     with pytest.raises(ValueError):
-        create_jira_ticket(jira_project_key="TEST", alert=glitchtip_alert)
+        create_jira_ticket(jira_project_key="TEST", issue=issue)


### PR DESCRIPTION
Fix a misunderstanding of alert attachments. A glitchtip alert may have multiple attachments and one attachment is an actual glitchtip issue.