### PR TITLE
support custom jira labels

### DIFF
--- a/glitchtip_jira_bridge/api/v1/alert.py
+++ b/glitchtip_jira_bridge/api/v1/alert.py
@@ -1,10 +1,12 @@
 import logging
 from collections.abc import Callable
+from typing import Annotated
 
 from celery import Task
 from fastapi import (
     APIRouter,
     Depends,
+    Query,
 )
 
 from ...models import GlitchtipAlert
@@ -27,8 +29,9 @@ def get_create_jira_ticket_func() -> Callable:
 def handle_alert(
     jira_project_key: str,
     alert: GlitchtipAlert,
+    labels: Annotated[list[str] | None, Query()] = None,
     create_jira_ticket: Task = Depends(get_create_jira_ticket_func),
 ) -> None:
     """Create new snapshot on all volumes."""
     for attachment in alert.attachments:
-        create_jira_ticket.delay(jira_project_key, attachment)
+        create_jira_ticket.delay(jira_project_key, attachment, labels or [])

--- a/glitchtip_jira_bridge/tasks.py
+++ b/glitchtip_jira_bridge/tasks.py
@@ -41,7 +41,9 @@ app = Celery(
 
 
 @app.task(bind=True)
-def create_jira_ticket(self: Task, jira_project_key: str, issue: Attachment) -> None:
+def create_jira_ticket(
+    self: Task, jira_project_key: str, issue: Attachment, custom_labels: list[str]
+) -> None:
     """Create a Jira ticket."""
     log.info(f"Handling alert '{issue.text}' for '{jira_project_key}' jira project")
     received_alerts.labels(jira_project_key).inc()
@@ -58,7 +60,7 @@ def create_jira_ticket(self: Task, jira_project_key: str, issue: Attachment) -> 
             summary=issue.title,
             description=f"{issue.text}\n-----\nGlitchtip issue: {issue.title_link}",
             url=issue.title_link,
-            labels=["glitchtip"] + issue.labels,
+            labels=["glitchtip"] + issue.labels + custom_labels,
             jira=JIRA(
                 server=settings.jira_api_url,
                 token_auth=settings.jira_api_key,

--- a/tests/api/test_alert.py
+++ b/tests/api/test_alert.py
@@ -41,6 +41,50 @@ def test_handle_alert(
                 )
             ],
         ),
+        params=dict(labels=["test-label"]),
     )
     assert response.status_code == 202
-    task_mock.delay.assert_called_once_with("JIRA-PROJECT-KEY", mocker.ANY)
+    task_mock.delay.assert_called_once_with(
+        "JIRA-PROJECT-KEY", mocker.ANY, ["test-label"]
+    )
+
+
+def test_handle_alert_no_labels(
+    mocker: MockerFixture, config_api_key: list[str], client: TestClient
+) -> None:
+    task_mock = mocker.MagicMock(Task, autospec=True)
+    client.app.dependency_overrides[  # type: ignore
+        get_create_jira_ticket_func
+    ] = lambda: task_mock
+    response = client.post(
+        "/api/v1/alert/JIRA-PROJECT-KEY",
+        headers={"Authorization": f"Bearer {config_api_key[0]}"},
+        json=dict(
+            alias="test alias",
+            text="test text",
+            attachments=[
+                dict(
+                    title="issue title",
+                    title_link="https://glitchtip.devshift.net/app-sre/issues/12345",
+                    text="issue text",
+                    image_url="https://google.com",
+                    color="#FF0000",
+                    fields=[
+                        dict(
+                            title="test",
+                            value="test",
+                            short=True,
+                        ),
+                        dict(
+                            title="Project",
+                            value="test-project",
+                            short=True,
+                        ),
+                    ],
+                    mrkdown_in=["text"],
+                )
+            ],
+        ),
+    )
+    assert response.status_code == 202
+    task_mock.delay.assert_called_once_with("JIRA-PROJECT-KEY", mocker.ANY, [])

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -12,14 +12,16 @@ def test_create_jira_ticket(mocker: MockerFixture, issue: Attachment) -> None:
     mocker.patch("glitchtip_jira_bridge.tasks.JIRA", autospec=True)
     mocker.patch("glitchtip_jira_bridge.tasks.boto3", autospec=True)
 
-    create_jira_ticket(jira_project_key="TEST", issue=issue)
+    create_jira_ticket(
+        jira_project_key="TEST", issue=issue, custom_labels=["custom-label-1"]
+    )
 
     create_issue_mock.assert_called_once_with(
         project_key="TEST",
         summary=issue.title,
         description="issue text\n-----\nGlitchtip issue: https://glitchtip.devshift.net/app-sre/issues/12345",
         url="https://glitchtip.devshift.net/app-sre/issues/12345",
-        labels=["glitchtip"] + issue.labels,
+        labels=["glitchtip"] + issue.labels + ["custom-label-1"],
         jira=mocker.ANY,
         issue_cache=mocker.ANY,
         limits=mocker.ANY,
@@ -35,4 +37,6 @@ def test_create_jira_ticket_retry(mocker: MockerFixture, issue: Attachment) -> N
     mocker.patch("glitchtip_jira_bridge.tasks.boto3", autospec=True)
 
     with pytest.raises(ValueError):
-        create_jira_ticket(jira_project_key="TEST", issue=issue)
+        create_jira_ticket(
+            jira_project_key="TEST", issue=issue, custom_labels=["custom-label-1"]
+        )


### PR DESCRIPTION
Add support for custom labels on Jira alert tickets.

Ticket: [APPSRE-8523](https://issues.redhat.com/browse/APPSRE-8523)
See also: https://github.com/app-sre/qontract-reconcile/pull/3936