### PR TITLE
:sparkles: support Jira components and custom issue types

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+echo "Starting GlitchTip Jira Bridge"
+
 if [[ "${GJB_DEBUG}" == "1" ]]; then
     set -x
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ./localstack:/etc/localstack/init/ready.d
 
   web:
+    restart: always
     env_file:
       - settings.conf
     environment:
@@ -26,6 +27,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: release
     ports:
       - "8080:8080"
     depends_on:
@@ -34,6 +36,7 @@ services:
       - ./glitchtip_jira_bridge:/code/glitchtip_jira_bridge
 
   worker:
+    restart: always
     env_file:
       - settings.conf
     environment:
@@ -44,6 +47,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      target: release
     ports:
       - "8000:8000"
     depends_on:

--- a/glitchtip_jira_bridge/api/v1/alert.py
+++ b/glitchtip_jira_bridge/api/v1/alert.py
@@ -30,8 +30,16 @@ def handle_alert(
     jira_project_key: str,
     alert: GlitchtipAlert,
     labels: Annotated[list[str] | None, Query()] = None,
+    components: Annotated[list[str] | None, Query()] = None,
+    issue_type: Annotated[str | None, Query()] = None,
     create_jira_ticket: Task = Depends(get_create_jira_ticket_func),
 ) -> None:
     """Create new snapshot on all volumes."""
     for attachment in alert.attachments:
-        create_jira_ticket.delay(jira_project_key, attachment, labels or [])
+        create_jira_ticket.delay(
+            jira_project_key,
+            attachment,
+            labels or [],
+            components or [],
+            issue_type or "Bug",
+        )

--- a/glitchtip_jira_bridge/api/v1/alert.py
+++ b/glitchtip_jira_bridge/api/v1/alert.py
@@ -26,7 +26,7 @@ def get_create_jira_ticket_func() -> Callable:
     summary="Create a Jira ticket.",
     status_code=202,
 )
-def handle_alert(
+def handle_alert(  # pylint: disable=too-many-arguments
     jira_project_key: str,
     alert: GlitchtipAlert,
     labels: Annotated[list[str] | None, Query()] = None,

--- a/glitchtip_jira_bridge/backends/jira.py
+++ b/glitchtip_jira_bridge/backends/jira.py
@@ -1,5 +1,5 @@
 import logging
-from typing import cast
+from typing import Any, cast
 
 from jira import JIRA
 from jira.client import ResultList
@@ -24,6 +24,8 @@ def create_issue(  # pylint: disable=too-many-arguments
     description: str,
     url: str,
     labels: list[str],
+    components: list[str],
+    issue_type: str,
     jira: JIRA,
     issue_cache: IssueCache,
     limits: Limits,
@@ -44,12 +46,18 @@ def create_issue(  # pylint: disable=too-many-arguments
             return
         # create new ticket
         log.info(f"Creating new Jira ticket for {url}")
+        extra_fields: dict[str, Any] = {}
+        if components:
+            extra_fields["components"] = [
+                {"name": component} for component in components
+            ]
         issue = jira.create_issue(
             project=project_key,
             summary=summary,
             description=description,
             labels=labels + [url],
-            issuetype={"name": "Bug"},
+            issuetype={"name": issue_type},
+            **extra_fields,
         )
         tickets_created.labels(project_key).inc()
         log.info(f"Jira ticket created {issue.key} ({issue.permalink()})")

--- a/glitchtip_jira_bridge/backends/jira.py
+++ b/glitchtip_jira_bridge/backends/jira.py
@@ -1,5 +1,8 @@
 import logging
-from typing import Any, cast
+from typing import (
+    Any,
+    cast,
+)
 
 from jira import JIRA
 from jira.client import ResultList

--- a/glitchtip_jira_bridge/tasks.py
+++ b/glitchtip_jira_bridge/tasks.py
@@ -43,7 +43,12 @@ app = Celery(
 
 @app.task(bind=True)
 def create_jira_ticket(
-    self: Task, jira_project_key: str, issue: Attachment, custom_labels: list[str]
+    self: Task,
+    jira_project_key: str,
+    issue: Attachment,
+    custom_labels: list[str],
+    components: list[str],
+    issue_type: str,
 ) -> None:
     """Create a Jira ticket."""
     log.info(f"Handling alert '{issue.text}' for '{jira_project_key}' jira project")
@@ -62,6 +67,8 @@ def create_jira_ticket(
             description=f"{issue.text}\n-----\nGlitchtip issue: {issue.title_link}",
             url=issue.title_link,
             labels=["glitchtip"] + issue.labels + custom_labels,
+            components=components,
+            issue_type=issue_type,
             jira=JIRA(
                 server=settings.jira_api_url,
                 token_auth=settings.jira_api_key,

--- a/glitchtip_jira_bridge/tasks.py
+++ b/glitchtip_jira_bridge/tasks.py
@@ -42,7 +42,7 @@ app = Celery(
 
 
 @app.task(bind=True)
-def create_jira_ticket(
+def create_jira_ticket(  # pylint: disable=too-many-arguments
     self: Task,
     jira_project_key: str,
     issue: Attachment,

--- a/tests/api/test_alert.py
+++ b/tests/api/test_alert.py
@@ -41,15 +41,23 @@ def test_handle_alert(
                 )
             ],
         ),
-        params=dict(labels=["test-label"]),
+        params=dict(
+            labels=["test-label"],
+            components=["test-component", "test-component-2"],
+            issue_type="issue-type",
+        ),
     )
     assert response.status_code == 202
     task_mock.delay.assert_called_once_with(
-        "JIRA-PROJECT-KEY", mocker.ANY, ["test-label"]
+        "JIRA-PROJECT-KEY",
+        mocker.ANY,
+        ["test-label"],
+        ["test-component", "test-component-2"],
+        "issue-type",
     )
 
 
-def test_handle_alert_no_labels(
+def test_handle_alert_no_optional_fields(
     mocker: MockerFixture, config_api_key: list[str], client: TestClient
 ) -> None:
     task_mock = mocker.MagicMock(Task, autospec=True)
@@ -87,4 +95,6 @@ def test_handle_alert_no_labels(
         ),
     )
     assert response.status_code == 202
-    task_mock.delay.assert_called_once_with("JIRA-PROJECT-KEY", mocker.ANY, [])
+    task_mock.delay.assert_called_once_with(
+        "JIRA-PROJECT-KEY", mocker.ANY, [], [], "Bug"
+    )

--- a/tests/backends/test_jira.py
+++ b/tests/backends/test_jira.py
@@ -22,6 +22,8 @@ def test_create_issue_new_ticket(mocker: MockerFixture) -> None:
         description="description",
         url="https://glitchtip.example.com/issue/123",
         labels=["label"],
+        components=["component"],
+        issue_type="issue_type",
         jira=jira_mock,
         issue_cache=issue_cache_mock,
         limits=limits_mock,
@@ -38,7 +40,52 @@ def test_create_issue_new_ticket(mocker: MockerFixture) -> None:
         summary="summary",
         description="description",
         labels=["label", "https://glitchtip.example.com/issue/123"],
-        issuetype={"name": "Bug"},
+        components=[{"name": "component"}],
+        issuetype={"name": "issue_type"},
+    )
+    issue_cache_mock.set.assert_called_once_with(
+        jira_key="JIRA-123", issue_url="https://glitchtip.example.com/issue/123"
+    )
+    limits_mock.is_allowed.assert_called_once_with("PROJECT")
+
+
+def test_create_issue_new_ticket_no_components(mocker: MockerFixture) -> None:
+    jira_mock = mocker.MagicMock()
+    jira_mock.search_issues.return_value = []
+    issue_mock = mocker.MagicMock()
+    issue_mock.key = "JIRA-123"
+    issue_mock.fields.resolution = None
+    jira_mock.create_issue.return_value = issue_mock
+    issue_cache_mock = mocker.MagicMock()
+    issue_cache_mock.get.return_value = None
+    limits_mock = mocker.MagicMock()
+    limits_mock.is_allowed.return_value = True
+
+    create_issue(
+        project_key="PROJECT",
+        summary="summary",
+        description="description",
+        url="https://glitchtip.example.com/issue/123",
+        labels=["label"],
+        components=[],
+        issue_type="issue_type",
+        jira=jira_mock,
+        issue_cache=issue_cache_mock,
+        limits=limits_mock,
+    )
+
+    issue_cache_mock.get.assert_called_once_with(
+        "https://glitchtip.example.com/issue/123"
+    )
+    jira_mock.search_issues.assert_called_once_with(
+        "labels='https://glitchtip.example.com/issue/123'"
+    )
+    jira_mock.create_issue.assert_called_once_with(
+        project="PROJECT",
+        summary="summary",
+        description="description",
+        labels=["label", "https://glitchtip.example.com/issue/123"],
+        issuetype={"name": "issue_type"},
     )
     issue_cache_mock.set.assert_called_once_with(
         jira_key="JIRA-123", issue_url="https://glitchtip.example.com/issue/123"
@@ -64,6 +111,8 @@ def test_create_issue_limits_hit(mocker: MockerFixture) -> None:
         description="description",
         url="https://glitchtip.example.com/issue/123",
         labels=["label"],
+        components=["component"],
+        issue_type="issue_type",
         jira=jira_mock,
         issue_cache=issue_cache_mock,
         limits=limits_mock,
@@ -98,6 +147,8 @@ def test_create_issue_ticket_exists_but_not_cached(mocker: MockerFixture) -> Non
         description="description",
         url="https://glitchtip.example.com/issue/123",
         labels=["label"],
+        components=["component"],
+        issue_type="issue_type",
         jira=jira_mock,
         issue_cache=issue_cache_mock,
         limits=limits_mock,
@@ -137,6 +188,8 @@ def test_create_issue_ticket_already_cached(mocker: MockerFixture) -> None:
         description="description",
         url="https://glitchtip.example.com/issue/123",
         labels=["label"],
+        components=["component"],
+        issue_type="issue_type",
         jira=jira_mock,
         issue_cache=issue_cache_mock,
         limits=limits_mock,
@@ -170,6 +223,8 @@ def test_create_issue_ticket_reopen(mocker: MockerFixture) -> None:
         description="description",
         url="https://glitchtip.example.com/issue/123",
         labels=["label"],
+        components=["component"],
+        issue_type="issue_type",
         jira=jira_mock,
         issue_cache=issue_cache_mock,
         limits=limits_mock,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -13,7 +13,11 @@ def test_create_jira_ticket(mocker: MockerFixture, issue: Attachment) -> None:
     mocker.patch("glitchtip_jira_bridge.tasks.boto3", autospec=True)
 
     create_jira_ticket(
-        jira_project_key="TEST", issue=issue, custom_labels=["custom-label-1"]
+        jira_project_key="TEST",
+        issue=issue,
+        custom_labels=["custom-label-1"],
+        components=["component-1"],
+        issue_type="issue-type",
     )
 
     create_issue_mock.assert_called_once_with(
@@ -22,6 +26,8 @@ def test_create_jira_ticket(mocker: MockerFixture, issue: Attachment) -> None:
         description="issue text\n-----\nGlitchtip issue: https://glitchtip.devshift.net/app-sre/issues/12345",
         url="https://glitchtip.devshift.net/app-sre/issues/12345",
         labels=["glitchtip"] + issue.labels + ["custom-label-1"],
+        components=["component-1"],
+        issue_type="issue-type",
         jira=mocker.ANY,
         issue_cache=mocker.ANY,
         limits=mocker.ANY,
@@ -38,5 +44,9 @@ def test_create_jira_ticket_retry(mocker: MockerFixture, issue: Attachment) -> N
 
     with pytest.raises(ValueError):
         create_jira_ticket(
-            jira_project_key="TEST", issue=issue, custom_labels=["custom-label-1"]
+            jira_project_key="TEST",
+            issue=issue,
+            custom_labels=["custom-label-1"],
+            components=["component-1"],
+            issue_type="issue-type",
         )


### PR DESCRIPTION
Add support for Jira components and don't enforce issue type "Bug".

Ticket: [APPSRE-10356](https://issues.redhat.com/browse/APPSRE-10356)