### PR TITLE
remove slack logging

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -216,16 +216,16 @@ objects:
               </exclude>
             </filter>
 
-            <match integration>
-              @type copy
-              <store>
-                @type slack
-                webhook_url ${SLACK_WEBHOOK_URL}
-                icon_emoji ${SLACK_ICON_EMOJI}
-                flush_interval 10s
-                message "\`\`\`[glitchtip-jira-bridge] %s\`\`\`"
-              </store>
-            </match>
+            #<match integration>
+            #  @type copy
+            #  <store>
+            #    @type slack
+            #    webhook_url ${SLACK_WEBHOOK_URL}
+            #    icon_emoji ${SLACK_ICON_EMOJI}
+            #    flush_interval 10s
+            #    message "\`\`\`[glitchtip-jira-bridge] %s\`\`\`"
+            #  </store>
+            #</match>
             EOF
         containers:
         - env:


### PR DESCRIPTION
We receive quite a lot of messages in slack. Currently this often obfuscates output from other integrations.

In this PR we remove the fluentd entry that is responsible for slack forwarding