### PR TITLE
Ignore RUF076 (pytest-fixture-autouse) lint rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ ignore = [
     "COM812",
     "COM819",
     "ISC001",
+    "RUF076",  # pytest-fixture-autouse (https://github.com/astral-sh/ruff/issues/26178)
 ]
 [tool.ruff.format]
 preview = true


### PR DESCRIPTION
## Summary
- Ignore ruff rule RUF076 (`pytest-fixture-autouse`) in lint config
- RUF076 was introduced in ruff 0.15.13 and flags `@pytest.fixture(autouse=True)` usage
- Upstream issue requesting conftest.py exemption: https://github.com/astral-sh/ruff/issues/26178
- Jira: https://redhat.atlassian.net/browse/APPSRE-14638

## Context
Renovate's pep621 dependency update PRs bump ruff to >=0.15.13, which enables this rule and breaks CI lint. This change unblocks those PRs by suppressing the rule project-wide until upstream resolves the default behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)