### PR TITLE
fix: drop pickle serialization from Celery to prevent RCE (APPSRE-14949)

### DIFF
--- a/glitchtip_jira_bridge/api/v1/alert.py
+++ b/glitchtip_jira_bridge/api/v1/alert.py
@@ -40,7 +40,7 @@ def handle_alert(
     for attachment in alert.attachments:
         create_jira_ticket.delay(
             jira_project_key,
-            attachment,
+            attachment.model_dump(),
             labels or [],
             components or [],
             issue_type or "Bug",

--- a/glitchtip_jira_bridge/tasks.py
+++ b/glitchtip_jira_bridge/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import boto3
 from celery import Celery
@@ -13,11 +13,10 @@ from .backends.db import (
 from .backends.jira import create_issue
 from .config import settings
 from .metrics import received_alerts
+from .models import Attachment
 
 if TYPE_CHECKING:
     from celery.app.task import Task
-
-    from .models import Attachment
 
 log = logging.getLogger(__name__)
 app = Celery(
@@ -36,12 +35,11 @@ app = Celery(
     broker_connection_retry_on_startup=True,
     worker_enable_remote_control=False,
     worker_log_format="[%(asctime)s: GJB] %(message)s",
-    # support pydantic models
-    task_serializer="pickle",
-    result_serializer="pickle",
+    task_serializer="json",
+    result_serializer="json",
     event_serializer="json",
-    accept_content=["application/json", "application/x-python-serialize"],
-    result_accept_content=["application/json", "application/x-python-serialize"],
+    accept_content=["application/json"],
+    result_accept_content=["application/json"],
 )
 
 
@@ -49,13 +47,16 @@ app = Celery(
 def create_jira_ticket(  # pylint: disable=too-many-arguments
     self: Task,
     jira_project_key: str,
-    issue: Attachment,
+    issue: dict[str, Any],
     custom_labels: list[str],
     components: list[str],
     issue_type: str,
 ) -> None:
     """Create a Jira ticket."""
-    log.info(f"Handling alert '{issue.text}' for '{jira_project_key}' jira project")
+    attachment = Attachment.model_validate(issue)
+    log.info(
+        f"Handling alert '{attachment.text}' for '{jira_project_key}' jira project"
+    )
     received_alerts.labels(jira_project_key).inc()
     try:
         dynamodb_service_resource = boto3.resource(
@@ -67,10 +68,10 @@ def create_jira_ticket(  # pylint: disable=too-many-arguments
         )
         create_issue(
             project_key=jira_project_key,
-            summary=issue.title,
-            description=f"{issue.text}\n-----\nGlitchtip issue: {issue.title_link}",
-            url=issue.title_link,
-            labels=["glitchtip", *issue.labels, *custom_labels],
+            summary=attachment.title,
+            description=f"{attachment.text}\n-----\nGlitchtip issue: {attachment.title_link}",
+            url=attachment.title_link,
+            labels=["glitchtip", *attachment.labels, *custom_labels],
             components=components,
             issue_type=issue_type,
             jira=JIRA(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,12 +2,19 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from glitchtip_jira_bridge.tasks import create_jira_ticket
+from glitchtip_jira_bridge.tasks import app, create_jira_ticket
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
     from glitchtip_jira_bridge.models import Attachment
+
+
+def test_celery_app_does_not_accept_pickle() -> None:
+    assert app.conf.task_serializer == "json"
+    assert app.conf.result_serializer == "json"
+    assert app.conf.accept_content == ["application/json"]
+    assert app.conf.result_accept_content == ["application/json"]
 
 
 def test_create_jira_ticket(mocker: MockerFixture, issue: Attachment) -> None:
@@ -19,7 +26,7 @@ def test_create_jira_ticket(mocker: MockerFixture, issue: Attachment) -> None:
 
     create_jira_ticket(
         jira_project_key="TEST",
-        issue=issue,
+        issue=issue.model_dump(),
         custom_labels=["custom-label-1"],
         components=["component-1"],
         issue_type="issue-type",
@@ -50,7 +57,7 @@ def test_create_jira_ticket_retry(mocker: MockerFixture, issue: Attachment) -> N
     with pytest.raises(ValueError):  # ruff: ignore[pytest-raises-too-broad]
         create_jira_ticket(
             jira_project_key="TEST",
-            issue=issue,
+            issue=issue.model_dump(),
             custom_labels=["custom-label-1"],
             components=["component-1"],
             issue_type="issue-type",


### PR DESCRIPTION
## Summary
- Security audit finding FIND-001 (High, CWE-502): Celery was configured with `task_serializer='pickle'` and accepted `application/x-python-serialize`, so the worker unpickled any message from the SQS broker. Any principal able to write to that queue could execute arbitrary code on the worker.
- Switched Celery to `json` serialization only (`task_serializer`, `result_serializer`, `accept_content`, `result_accept_content`).
- `create_jira_ticket` now receives the `Attachment` as a plain dict (`model_dump()`) over the wire and re-validates it with `Attachment.model_validate()` inside the task.

## Test plan
- [x] Added `test_celery_app_does_not_accept_pickle`, which fails against the old config and passes against the new one (confirmed both ways).
- [x] `uv run pytest` — 24 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy glitchtip_jira_bridge` — no issues