### PR TITLE
fix: escape JQL string literals and scope search to project (APPSRE-14950)

### DIFF
--- a/glitchtip_jira_bridge/backends/jira.py
+++ b/glitchtip_jira_bridge/backends/jira.py
@@ -20,6 +20,11 @@ from glitchtip_jira_bridge.metrics import (
 log = logging.getLogger(__name__)
 
 
+def _escape_jql_string(value: str) -> str:
+    """Escape a value for safe inclusion in a single-quoted JQL string literal."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
 def create_issue(  # pylint: disable=too-many-arguments
     project_key: str,
     summary: str,
@@ -38,7 +43,11 @@ def create_issue(  # pylint: disable=too-many-arguments
         return
 
     # ticket not cached, fetch from jira if it exists
-    issues = cast("ResultList[Issue]", jira.search_issues(f"labels='{url}'"))
+    jql = (
+        f"project = '{_escape_jql_string(project_key)}' "
+        f"AND labels = '{_escape_jql_string(url)}'"
+    )
+    issues = cast("ResultList[Issue]", jira.search_issues(jql))
     if not issues:
         if not limits.is_allowed(project_key):
             limit_reached.labels(project_key).inc()

--- a/tests/backends/test_jira.py
+++ b/tests/backends/test_jira.py
@@ -7,6 +7,39 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+def test_create_issue_escapes_jql_injection_in_url(mocker: MockerFixture) -> None:
+    jira_mock = mocker.MagicMock()
+    jira_mock.search_issues.return_value = []
+    issue_mock = mocker.MagicMock()
+    issue_mock.key = "JIRA-123"
+    issue_mock.fields.resolution = None
+    jira_mock.create_issue.return_value = issue_mock
+    issue_cache_mock = mocker.MagicMock()
+    issue_cache_mock.get.return_value = None
+    limits_mock = mocker.MagicMock()
+    limits_mock.is_allowed.return_value = True
+
+    malicious_url = "https://example.com' OR project=SECRET OR labels='x"
+
+    create_issue(
+        project_key="PROJECT",
+        summary="summary",
+        description="description",
+        url=malicious_url,
+        labels=["label"],
+        components=["component"],
+        issue_type="issue_type",
+        jira=jira_mock,
+        issue_cache=issue_cache_mock,
+        limits=limits_mock,
+    )
+
+    jira_mock.search_issues.assert_called_once_with(
+        "project = 'PROJECT' AND labels = "
+        "'https://example.com\\' OR project=SECRET OR labels=\\'x'"
+    )
+
+
 def test_create_issue_new_ticket(mocker: MockerFixture) -> None:
     jira_mock = mocker.MagicMock()
     jira_mock.search_issues.return_value = []
@@ -36,7 +69,7 @@ def test_create_issue_new_ticket(mocker: MockerFixture) -> None:
         "https://glitchtip.example.com/issue/123"
     )
     jira_mock.search_issues.assert_called_once_with(
-        "labels='https://glitchtip.example.com/issue/123'"
+        "project = 'PROJECT' AND labels = 'https://glitchtip.example.com/issue/123'"
     )
     jira_mock.create_issue.assert_called_once_with(
         project="PROJECT",
@@ -81,7 +114,7 @@ def test_create_issue_new_ticket_no_components(mocker: MockerFixture) -> None:
         "https://glitchtip.example.com/issue/123"
     )
     jira_mock.search_issues.assert_called_once_with(
-        "labels='https://glitchtip.example.com/issue/123'"
+        "project = 'PROJECT' AND labels = 'https://glitchtip.example.com/issue/123'"
     )
     jira_mock.create_issue.assert_called_once_with(
         project="PROJECT",
@@ -125,7 +158,7 @@ def test_create_issue_limits_hit(mocker: MockerFixture) -> None:
         "https://glitchtip.example.com/issue/123"
     )
     jira_mock.search_issues.assert_called_once_with(
-        "labels='https://glitchtip.example.com/issue/123'"
+        "project = 'PROJECT' AND labels = 'https://glitchtip.example.com/issue/123'"
     )
     jira_mock.create_issue.assert_not_called()
     issue_cache_mock.set.assert_not_called()
@@ -161,7 +194,7 @@ def test_create_issue_ticket_exists_but_not_cached(mocker: MockerFixture) -> Non
         "https://glitchtip.example.com/issue/123"
     )
     jira_mock.search_issues.assert_called_once_with(
-        "labels='https://glitchtip.example.com/issue/123'"
+        "project = 'PROJECT' AND labels = 'https://glitchtip.example.com/issue/123'"
     )
     jira_mock.create_issue.assert_not_called()
     issue_cache_mock.set.assert_called_once_with(
@@ -238,7 +271,7 @@ def test_create_issue_ticket_reopen(mocker: MockerFixture) -> None:
         "https://glitchtip.example.com/issue/123"
     )
     jira_mock.search_issues.assert_called_once_with(
-        "labels='https://glitchtip.example.com/issue/123'"
+        "project = 'PROJECT' AND labels = 'https://glitchtip.example.com/issue/123'"
     )
     jira_mock.create_issue.assert_not_called()
     jira_mock.transition_issue.assert_called_once_with(issue_mock, "1")
@@ -279,7 +312,7 @@ def test_create_issue_ticket_no_reopen_for_wont_do(mocker: MockerFixture) -> Non
         "https://glitchtip.example.com/issue/123"
     )
     jira_mock.search_issues.assert_called_once_with(
-        "labels='https://glitchtip.example.com/issue/123'"
+        "project = 'PROJECT' AND labels = 'https://glitchtip.example.com/issue/123'"
     )
     jira_mock.create_issue.assert_not_called()
     jira_mock.transition_issue.assert_not_called()


### PR DESCRIPTION
## Summary
- Security audit finding FIND-002 (Medium, CWE-943/CWE-74): `create_issue()` built the JQL query with an f-string (`labels='{url}'`) using the attacker-controlled Glitchtip `title_link` without escaping. A caller could supply a `title_link` containing a single quote to inject arbitrary JQL, enumerating or transitioning Jira issues outside the intended project.
- Added `_escape_jql_string()` to escape backslashes and single quotes before interpolating into the JQL string literal.
- Applied it to both `url` and `project_key`, and added `AND project = '<project_key>'` to scope the search to the intended project as defense-in-depth.

## Test plan
- [x] Added `test_create_issue_escapes_jql_injection_in_url`, which fails against the old unescaped f-string and passes against the fix (confirmed both ways).
- [x] Updated existing `search_issues` assertions for the new query shape.
- [x] `uv run pytest` — 24 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy glitchtip_jira_bridge` — no issues