### PR TITLE
fix: redact token query param from uvicorn access logs (APPSRE-14951)

### DIFF
--- a/glitchtip_jira_bridge/logging_utils.py
+++ b/glitchtip_jira_bridge/logging_utils.py
@@ -1,0 +1,25 @@
+import logging
+import re
+from typing import override
+
+_TOKEN_QUERY_PARAM_RE = re.compile(r"(?i)([?&]token=)[^&\s]*")
+
+
+class RedactTokenQueryParamFilter(logging.Filter):
+    """Redact the `token` query parameter from log records.
+
+    The `/api/v1/alert` endpoint accepts the API key as a `?token=` query
+    parameter (Glitchtip cannot send custom headers), which uvicorn's access
+    logger would otherwise write to stdout/container logs in full.
+    """
+
+    @override
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.args, tuple):
+            record.args = tuple(
+                _TOKEN_QUERY_PARAM_RE.sub(r"\1REDACTED", arg)
+                if isinstance(arg, str)
+                else arg
+                for arg in record.args
+            )
+        return True

--- a/glitchtip_jira_bridge/main.py
+++ b/glitchtip_jira_bridge/main.py
@@ -15,9 +15,14 @@ from prometheus_fastapi_instrumentator import Instrumentator
 from glitchtip_jira_bridge.api import router
 from glitchtip_jira_bridge.config import settings
 from glitchtip_jira_bridge.dependencies import api_key_auth
+from glitchtip_jira_bridge.logging_utils import RedactTokenQueryParamFilter
 
 HOSTNAME = socket.gethostname()
 default_router = APIRouter()
+
+# the API key can be passed as a `?token=` query param (Glitchtip cannot send
+# custom headers), so scrub it from uvicorn's access log before it's written
+logging.getLogger("uvicorn.access").addFilter(RedactTokenQueryParamFilter())
 
 
 @default_router.get("/healthz", include_in_schema=False)

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,43 @@
+import logging
+
+from glitchtip_jira_bridge.logging_utils import RedactTokenQueryParamFilter
+
+
+def _make_record(path_with_query: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:12345", "POST", path_with_query, "1.1", 202),
+        exc_info=None,
+    )
+
+
+def test_redacts_token_query_param() -> None:
+    record = _make_record("/api/v1/alert/PROJECT?token=super-secret-key")
+
+    assert RedactTokenQueryParamFilter().filter(record) is True
+    assert record.getMessage() == (
+        '127.0.0.1:12345 - "POST /api/v1/alert/PROJECT?token=REDACTED HTTP/1.1" 202'
+    )
+
+
+def test_redacts_token_query_param_among_other_params() -> None:
+    record = _make_record("/api/v1/alert/PROJECT?labels=foo&token=super-secret-key")
+
+    assert RedactTokenQueryParamFilter().filter(record) is True
+    assert record.getMessage() == (
+        '127.0.0.1:12345 - "POST /api/v1/alert/PROJECT?labels=foo&token=REDACTED '
+        'HTTP/1.1" 202'
+    )
+
+
+def test_leaves_requests_without_token_untouched() -> None:
+    record = _make_record("/healthz?foo=bar")
+
+    assert RedactTokenQueryParamFilter().filter(record) is True
+    assert record.getMessage() == (
+        '127.0.0.1:12345 - "POST /healthz?foo=bar HTTP/1.1" 202'
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,12 @@
+import logging
+
+import glitchtip_jira_bridge.main  # ruff: ignore[unused-import]
+from glitchtip_jira_bridge.logging_utils import RedactTokenQueryParamFilter
+
+
+def test_uvicorn_access_logger_has_redact_token_filter() -> None:
+    access_logger = logging.getLogger("uvicorn.access")
+
+    assert any(
+        isinstance(f, RedactTokenQueryParamFilter) for f in access_logger.filters
+    )


### PR DESCRIPTION
## Summary
- Security audit finding FIND-003 (Medium, CWE-598): `api_key_auth()` accepts the bearer token via a `?token=` query parameter, and uvicorn's default access log writes the full request line — including the raw token — to stdout/container logs on every request.
- Glitchtip cannot send custom headers, so the query-param auth path has to stay; switching to header-only or short-lived tokens would mean reworking the app-interface Glitchtip integration itself, which is out of scope for this fix.
- Instead, added a `logging.Filter` (`RedactTokenQueryParamFilter`) attached to the `uvicorn.access` logger that redacts the `token=` value from the request line before it's emitted, regardless of query param order/position.

## Test plan
- [x] Added `tests/test_logging_utils.py` covering: token alone, token among other params, and requests without a token (untouched) — confirmed these fail without the filter and pass with it.
- [x] Added `tests/test_main.py::test_uvicorn_access_logger_has_redact_token_filter` to guard the wiring in `main.py`.
- [x] `uv run pytest` — 27 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy glitchtip_jira_bridge` — no issues