### PR TITLE
fix: mount secrets as files and disable SA token automount (APPSRE-14957, APPSRE-14958)

### DIFF
--- a/glitchtip_jira_bridge/config.py
+++ b/glitchtip_jira_bridge/config.py
@@ -1,7 +1,18 @@
 # ruff: file-ignore[hardcoded-password-string]
 from datetime import timedelta
+from pathlib import Path
 
 from pydantic_settings import BaseSettings
+
+# OpenShift mounts the glitchtip-jira-bridge-secret Secret here as files (one
+# per key) instead of injecting it via environment variables. Not present in
+# local/dev environments, which keep using env vars (see docker-compose.yml).
+SECRETS_DIR = Path("/var/run/secrets/glitchtip-jira-bridge")
+
+
+def resolve_secrets_dir(path: Path) -> Path | None:
+    """Return `path` if it exists, else None (avoids a pydantic-settings warning)."""
+    return path if path.is_dir() else None
 
 
 class Settings(BaseSettings):
@@ -40,7 +51,10 @@ class Settings(BaseSettings):
     worker_metrics_port: int = 8000
 
     # pydantic config
-    model_config = {"env_prefix": "gjb_"}
+    model_config = {
+        "env_prefix": "gjb_",
+        "secrets_dir": resolve_secrets_dir(SECRETS_DIR),
+    }
 
 
 settings = Settings()

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -11,6 +11,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
+  automountServiceAccountToken: false
   metadata:
     name: glitchtip-jira-bridge-web
     labels:
@@ -61,6 +62,11 @@ objects:
                     - web
                 topologyKey: kubernetes.io/hostname
               weight: 1
+        volumes:
+        - name: glitchtip-jira-bridge-secret
+          secret:
+            secretName: glitchtip-jira-bridge-secret
+            optional: true
         containers:
         - env:
           - name: GJB_START_MODE
@@ -68,12 +74,13 @@ objects:
           - name: GJB_APP_PORT
             value: "${GJB_APP_PORT}"
           envFrom:
-            - secretRef:
-                name: glitchtip-jira-bridge-secret
-                optional: true
             - configMapRef:
                 name: glitchtip-jira-bridge-config
                 optional: true
+          volumeMounts:
+          - name: glitchtip-jira-bridge-secret
+            mountPath: /var/run/secrets/glitchtip-jira-bridge
+            readOnly: true
           image: "${IMAGE}:${IMAGE_TAG}"
           name: web
           ports:
@@ -130,6 +137,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   imagePullSecrets: "${{IMAGE_PULL_SECRETS}}"
+  automountServiceAccountToken: false
   metadata:
     name: glitchtip-jira-bridge-worker
     labels:
@@ -180,6 +188,11 @@ objects:
                     - worker
                 topologyKey: kubernetes.io/hostname
               weight: 1
+        volumes:
+        - name: glitchtip-jira-bridge-secret
+          secret:
+            secretName: glitchtip-jira-bridge-secret
+            optional: true
         containers:
         - env:
           - name: GJB_START_MODE
@@ -187,12 +200,13 @@ objects:
           - name: GJB_WORKER_METRICS_PORT
             value: "${GJB_WORKER_METRICS_PORT}"
           envFrom:
-            - secretRef:
-                name: glitchtip-jira-bridge-secret
-                optional: true
             - configMapRef:
                 name: glitchtip-jira-bridge-config
                 optional: true
+          volumeMounts:
+          - name: glitchtip-jira-bridge-secret
+            mountPath: /var/run/secrets/glitchtip-jira-bridge
+            readOnly: true
           image: "${IMAGE}:${IMAGE_TAG}"
           name: worker
           ports:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,45 @@
+# ruff: file-ignore[hardcoded-password-string]
+from typing import TYPE_CHECKING
+
+from glitchtip_jira_bridge.config import SECRETS_DIR, Settings, resolve_secrets_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def test_resolve_secrets_dir_returns_path_when_directory_exists(
+    tmp_path: Path,
+) -> None:
+    assert resolve_secrets_dir(tmp_path) == tmp_path
+
+
+def test_resolve_secrets_dir_returns_none_when_directory_missing(
+    tmp_path: Path,
+) -> None:
+    assert resolve_secrets_dir(tmp_path / "does-not-exist") is None
+
+
+def test_settings_secrets_dir_is_wired_to_resolved_path() -> None:
+    assert Settings.model_config.get("secrets_dir") == resolve_secrets_dir(SECRETS_DIR)
+
+
+def test_settings_reads_secret_from_secrets_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "gjb_jira_api_token").write_text("file-token")
+    monkeypatch.setitem(Settings.model_config, "secrets_dir", tmp_path)
+    monkeypatch.delenv("GJB_JIRA_API_TOKEN", raising=False)
+
+    assert Settings().jira_api_token == "file-token"
+
+
+def test_settings_env_var_overrides_secrets_dir_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "gjb_jira_api_token").write_text("file-token")
+    monkeypatch.setitem(Settings.model_config, "secrets_dir", tmp_path)
+    monkeypatch.setenv("GJB_JIRA_API_TOKEN", "env-token")
+
+    assert Settings().jira_api_token == "env-token"


### PR DESCRIPTION
## Summary

Addresses two security audit findings together since both are OpenShift template hardening for the same deployments.

**FIND-008 (Low, CWE-526):** secrets (Jira token, AWS keys, API keys) were injected via `envFrom`/`secretRef`, landing in the process environment where they're inherited by child processes, visible in `/proc/<pid>/environ`, and captured in crash dumps.
- Mount the `glitchtip-jira-bridge-secret` Secret as a read-only volume on both the web and worker Deployments instead of `envFrom`.
- `Settings` now reads secrets via pydantic-settings' `secrets_dir` (`glitchtip_jira_bridge/config.py`), pointed at the new mount path.
- Env vars still take priority over `secrets_dir` files (pydantic-settings' default source order), so local/dev setups (`docker-compose.yml`, `settings.conf`) keep working unchanged — that path simply doesn't exist there, so `secrets_dir` resolves to `None` and is skipped with no warning.

**FIND-007 (Low, CWE-1188):** neither ServiceAccount set `automountServiceAccountToken`, projecting an unused Kubernetes API token into every pod even though the app never calls the Kubernetes API.
- Set `automountServiceAccountToken: false` on both the `glitchtip-jira-bridge-web` and `glitchtip-jira-bridge-worker` ServiceAccounts.

## Test plan
- [x] Added `tests/test_config.py`: `resolve_secrets_dir()` unit tests (existing/missing dir), a wiring check on `Settings.model_config`, and integration tests proving secret-file loading + env-var-overrides-file precedence — all confirmed failing before the code existed, passing after.
- [x] Verified locally with a real env var set that dev config loading is unaffected and no `secrets_dir`-missing warning is emitted (`python -W error::UserWarning`).
- [x] Validated `openshift/template.yaml` with `oc process --local -f openshift/template.yaml -p IMAGE=... -p IMAGE_TAG=...` — confirmed `automountServiceAccountToken: false`, the new `volumes`/`volumeMounts`, and `envFrom` (now configMap-only) render correctly for both web and worker.
- [x] `uv run pytest` — 34 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy glitchtip_jira_bridge` — no issues