### PR TITLE
docs: add SECURITY.md vulnerability disclosure policy (APPSRE-14960)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+This repository is a Red Hat AppSRE service that bridges [GlitchTip](https://glitchtip.com) alert webhooks into Jira tickets.
+
+## Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues or pull requests.
+
+To report a security issue in this repository, contact Red Hat Product Security:
+
+- Email: [secalert@redhat.com](mailto:secalert@redhat.com)
+- PGP key and additional details: <https://access.redhat.com/security/team/contact>
+
+Red Hat Product Security will acknowledge your report and coordinate remediation and disclosure.


### PR DESCRIPTION
## Summary
- Security audit finding FIND-010 (Informational, CWE-1059): the repository had no `SECURITY.md`, `.github/SECURITY.md`, or documented vulnerability-disclosure contact. OpenSSF Scorecard scores this 0/10 for the Security-Policy check.
- Added `SECURITY.md` pointing to Red Hat Product Security (`secalert@redhat.com`), matching the house style already used in the sibling `app-sre/glitchtip` repository (no org-level `app-sre/.github` SECURITY.md exists to inherit from).

## Test plan
- [x] `uv run pytest` — 29 passed (docs-only change, no test impact)
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy glitchtip_jira_bridge` — no issues