### PR TITLE
fix: accept GlitchTip's actual webhook payload shape

### DIFF
--- a/glitchtip_jira_bridge/models.py
+++ b/glitchtip_jira_bridge/models.py
@@ -10,7 +10,7 @@ class Field(BaseModel):
 class Attachment(BaseModel):
     title: str
     title_link: str
-    text: str | None
+    text: str | None = None
     image_url: str | None = None
     color: str | None = None
     fields: list[Field] | None = None
@@ -33,7 +33,6 @@ class Attachment(BaseModel):
 
 
 class GlitchtipAlert(BaseModel):
-    alias: str
     text: str
     attachments: list[Attachment]
     # pydantic config

--- a/tests/api/test_alert.py
+++ b/tests/api/test_alert.py
@@ -21,7 +21,6 @@ def test_handle_alert(
         "/api/v1/alert/JIRA-PROJECT-KEY",
         headers={"Authorization": f"Bearer {config_api_key[0]}"},
         json={
-            "alias": "test alias",
             "text": "test text",
             "attachments": [
                 {
@@ -62,6 +61,45 @@ def test_handle_alert(
     )
 
 
+def test_handle_alert_real_glitchtip_payload(
+    mocker: MockerFixture, config_api_key: list[str], client: TestClient
+) -> None:
+    """Real GlitchTip 6.2.x payload: no top-level `alias`, no attachment `text`."""
+    task_mock = mocker.MagicMock(Task, autospec=True)
+    client.app.dependency_overrides[  # type: ignore[attr-defined]
+        get_create_jira_ticket_func
+    ] = lambda: task_mock
+    response = client.post(
+        "/api/v1/alert/CCXDEV",
+        headers={"Authorization": f"Bearer {config_api_key[0]}"},
+        json={
+            "text": "GlitchTip Alert",
+            "attachments": [
+                {
+                    "title": "kafka: error while consuming ccx.ocp.results/0",
+                    "title_link": "https://glitchtip.devshift.net/ccx/issues/4580574",
+                    "color": "#e52b50",
+                    "fields": [
+                        {
+                            "title": "Project",
+                            "value": "ccx-notification-writer",
+                            "short": True,
+                        },
+                        {
+                            "title": "Environment",
+                            "value": "prod",
+                            "short": True,
+                        },
+                    ],
+                    "mrkdown_in": ["text"],
+                }
+            ],
+        },
+    )
+    assert response.status_code == requests.codes.accepted
+    task_mock.delay.assert_called_once_with("CCXDEV", mocker.ANY, [], [], "Bug")
+
+
 def test_handle_alert_no_optional_fields(
     mocker: MockerFixture, config_api_key: list[str], client: TestClient
 ) -> None:
@@ -73,7 +111,6 @@ def test_handle_alert_no_optional_fields(
         "/api/v1/alert/JIRA-PROJECT-KEY",
         headers={"Authorization": f"Bearer {config_api_key[0]}"},
         json={
-            "alias": "test alias",
             "text": "test text",
             "attachments": [
                 {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ def issue() -> Attachment:
 @pytest.fixture
 def glitchtip_alert(issue: Attachment) -> GlitchtipAlert:
     return GlitchtipAlert(
-        alias="test alias",
         text="test text",
         attachments=[issue.model_dump()],
     )


### PR DESCRIPTION
## Summary
- Every GlitchTip alert has been rejected with `422 Unprocessable Content` (confirmed via prod logs — 100% failure rate across all projects) because `GlitchtipAlert` required a top-level `alias` field that upstream GlitchTip stopped sending back in Feb 2026 (never used anywhere in this codebase).
- The recent GlitchTip 6.1.6 → 6.2.2/6.2.3 upgrade introduced a second failure mode on top: `Attachment.text` was required, but GlitchTip 6.2.x now omits that key entirely (instead of sending `null`) when an issue has no culprit (e.g. Kafka consumer errors).
- Test fixtures used an idealized payload including `alias`, which never matched what GlitchTip actually sends — that's how this went unnoticed for months.

## Changes
- `glitchtip_jira_bridge/models.py`: drop unused `alias` field, make `Attachment.text` default to `None` so the key can legitimately be absent.
- `tests/api/test_alert.py`: add `test_handle_alert_real_glitchtip_payload`, built from the exact payload captured in prod logs (fails against the old model, passes now).
- `tests/conftest.py`: drop `alias=` from the `glitchtip_alert` fixture.

## Test plan
- [x] New regression test reproduces the bug (422) before the fix, passes (202) after
- [x] `uv run pytest` — 35 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy` (strict) — no issues